### PR TITLE
feat: EmbeddingClient with Ollama and OpenAI providers

### DIFF
--- a/config/vector.php
+++ b/config/vector.php
@@ -13,4 +13,22 @@ return [
         'request' => (int) env('QDRANT_REQUEST_TIMEOUT', 30),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Embedding Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Provider: ollama, openai, none
+    | Model: provider-specific model name (e.g. bge-large, text-embedding-3-large)
+    |
+    */
+
+    'embeddings' => [
+        'provider' => env('EMBEDDING_PROVIDER', 'ollama'),
+        'model' => env('EMBEDDING_MODEL', 'bge-large'),
+        'url' => env('EMBEDDING_URL'),
+        'api_key' => env('EMBEDDING_API_KEY'),
+        'dimensions' => env('EMBEDDING_DIMENSIONS') ? (int) env('EMBEDDING_DIMENSIONS') : null,
+    ],
+
 ];

--- a/src/Contracts/EmbeddingClient.php
+++ b/src/Contracts/EmbeddingClient.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheShit\Vector\Contracts;
+
+interface EmbeddingClient
+{
+    /**
+     * Generate an embedding vector for the given text.
+     *
+     * @return array<float>
+     */
+    public function embed(string $text): array;
+
+    /**
+     * Generate embedding vectors for multiple texts.
+     *
+     * @param  array<string>  $texts
+     * @return array<array<float>>
+     */
+    public function embedBatch(array $texts): array;
+}

--- a/src/Embeddings/NullEmbeddings.php
+++ b/src/Embeddings/NullEmbeddings.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheShit\Vector\Embeddings;
+
+use TheShit\Vector\Contracts\EmbeddingClient;
+
+class NullEmbeddings implements EmbeddingClient
+{
+    /**
+     * @return array<float>
+     */
+    public function embed(string $text): array
+    {
+        return [];
+    }
+
+    /**
+     * @param  array<string>  $texts
+     * @return array<array<float>>
+     */
+    public function embedBatch(array $texts): array
+    {
+        return [];
+    }
+}

--- a/src/Embeddings/OllamaConnector.php
+++ b/src/Embeddings/OllamaConnector.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheShit\Vector\Embeddings;
+
+use Saloon\Http\Connector;
+use Saloon\Traits\Plugins\HasTimeout;
+
+class OllamaConnector extends Connector
+{
+    use HasTimeout;
+
+    protected int $connectTimeout = 5;
+
+    protected int $requestTimeout = 30;
+
+    public function __construct(
+        protected readonly string $baseUrl,
+    ) {}
+
+    public function resolveBaseUrl(): string
+    {
+        return rtrim($this->baseUrl, '/');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function defaultHeaders(): array
+    {
+        return [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ];
+    }
+}

--- a/src/Embeddings/OllamaEmbeddings.php
+++ b/src/Embeddings/OllamaEmbeddings.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheShit\Vector\Embeddings;
+
+use Saloon\Exceptions\Request\RequestException;
+use TheShit\Vector\Contracts\EmbeddingClient;
+use TheShit\Vector\Embeddings\Requests\OllamaEmbedRequest;
+
+class OllamaEmbeddings implements EmbeddingClient
+{
+    public function __construct(
+        protected readonly OllamaConnector $connector,
+        protected readonly string $model = 'bge-large',
+    ) {}
+
+    /**
+     * @return array<float>
+     */
+    public function embed(string $text): array
+    {
+        if (trim($text) === '') {
+            return [];
+        }
+
+        $result = $this->embedBatch([$text]);
+
+        return $result[0] ?? [];
+    }
+
+    /**
+     * @param  array<string>  $texts
+     * @return array<array<float>>
+     */
+    public function embedBatch(array $texts): array
+    {
+        $texts = array_values(array_filter($texts, fn (string $t): bool => trim($t) !== ''));
+
+        if ($texts === []) {
+            return [];
+        }
+
+        try {
+            $response = $this->connector->send(new OllamaEmbedRequest($this->model, $texts));
+            $response->throw();
+        } catch (RequestException) {
+            return array_fill(0, count($texts), []);
+        }
+
+        /** @var array<array<float>> $embeddings */
+        $embeddings = $response->json('embeddings') ?? [];
+
+        return array_map(
+            fn (mixed $embedding): array => is_array($embedding)
+                ? array_map(fn (mixed $v): float => (float) $v, $embedding)
+                : [],
+            $embeddings,
+        );
+    }
+}

--- a/src/Embeddings/OllamaEmbeddings.php
+++ b/src/Embeddings/OllamaEmbeddings.php
@@ -53,7 +53,7 @@ class OllamaEmbeddings implements EmbeddingClient
 
         return array_map(
             fn (mixed $embedding): array => is_array($embedding)
-                ? array_map(fn (mixed $v): float => (float) $v, $embedding)
+                ? array_map(fn (mixed $v): float => $v, $embedding)
                 : [],
             $embeddings,
         );

--- a/src/Embeddings/OpenAiConnector.php
+++ b/src/Embeddings/OpenAiConnector.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheShit\Vector\Embeddings;
+
+use Saloon\Http\Auth\TokenAuthenticator;
+use Saloon\Http\Connector;
+use Saloon\Traits\Plugins\HasTimeout;
+
+class OpenAiConnector extends Connector
+{
+    use HasTimeout;
+
+    protected int $connectTimeout = 5;
+
+    protected int $requestTimeout = 30;
+
+    public function __construct(
+        protected readonly string $baseUrl,
+        protected readonly string $apiKey,
+    ) {}
+
+    public function resolveBaseUrl(): string
+    {
+        return rtrim($this->baseUrl, '/');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function defaultHeaders(): array
+    {
+        return [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ];
+    }
+
+    protected function defaultAuth(): TokenAuthenticator
+    {
+        return new TokenAuthenticator($this->apiKey);
+    }
+}

--- a/src/Embeddings/OpenAiEmbeddings.php
+++ b/src/Embeddings/OpenAiEmbeddings.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheShit\Vector\Embeddings;
+
+use Saloon\Exceptions\Request\RequestException;
+use TheShit\Vector\Contracts\EmbeddingClient;
+use TheShit\Vector\Embeddings\Requests\OpenAiEmbedRequest;
+
+class OpenAiEmbeddings implements EmbeddingClient
+{
+    public function __construct(
+        protected readonly OpenAiConnector $connector,
+        protected readonly string $model = 'text-embedding-3-large',
+        protected readonly ?int $dimensions = null,
+    ) {}
+
+    /**
+     * @return array<float>
+     */
+    public function embed(string $text): array
+    {
+        if (trim($text) === '') {
+            return [];
+        }
+
+        $result = $this->embedBatch([$text]);
+
+        return $result[0] ?? [];
+    }
+
+    /**
+     * @param  array<string>  $texts
+     * @return array<array<float>>
+     */
+    public function embedBatch(array $texts): array
+    {
+        $texts = array_values(array_filter($texts, fn (string $t): bool => trim($t) !== ''));
+
+        if ($texts === []) {
+            return [];
+        }
+
+        try {
+            $response = $this->connector->send(new OpenAiEmbedRequest($this->model, $texts, $this->dimensions));
+            $response->throw();
+        } catch (RequestException) {
+            return array_fill(0, count($texts), []);
+        }
+
+        /** @var array<array{embedding: array<float>}> $data */
+        $data = $response->json('data') ?? [];
+
+        return array_map(
+            fn (mixed $item): array => is_array($item) && isset($item['embedding']) && is_array($item['embedding'])
+                ? array_map(fn (mixed $v): float => (float) $v, $item['embedding'])
+                : [],
+            $data,
+        );
+    }
+}

--- a/src/Embeddings/OpenAiEmbeddings.php
+++ b/src/Embeddings/OpenAiEmbeddings.php
@@ -54,7 +54,7 @@ class OpenAiEmbeddings implements EmbeddingClient
 
         return array_map(
             fn (mixed $item): array => is_array($item) && isset($item['embedding']) && is_array($item['embedding'])
-                ? array_map(fn (mixed $v): float => (float) $v, $item['embedding'])
+                ? array_map(fn (mixed $v): float => $v, $item['embedding'])
                 : [],
             $data,
         );

--- a/src/Embeddings/Requests/OllamaEmbedRequest.php
+++ b/src/Embeddings/Requests/OllamaEmbedRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheShit\Vector\Embeddings\Requests;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+class OllamaEmbedRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    /**
+     * @param  array<string>  $texts
+     */
+    public function __construct(
+        protected readonly string $model,
+        protected readonly array $texts,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/api/embed';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function defaultBody(): array
+    {
+        return [
+            'model' => $this->model,
+            'input' => $this->texts,
+        ];
+    }
+}

--- a/src/Embeddings/Requests/OpenAiEmbedRequest.php
+++ b/src/Embeddings/Requests/OpenAiEmbedRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheShit\Vector\Embeddings\Requests;
+
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Body\HasJsonBody;
+
+class OpenAiEmbedRequest extends Request implements HasBody
+{
+    use HasJsonBody;
+
+    protected Method $method = Method::POST;
+
+    /**
+     * @param  array<string>  $texts
+     */
+    public function __construct(
+        protected readonly string $model,
+        protected readonly array $texts,
+        protected readonly ?int $dimensions = null,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/v1/embeddings';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function defaultBody(): array
+    {
+        $body = [
+            'model' => $this->model,
+            'input' => $this->texts,
+        ];
+
+        if ($this->dimensions !== null) {
+            $body['dimensions'] = $this->dimensions;
+        }
+
+        return $body;
+    }
+}

--- a/src/VectorServiceProvider.php
+++ b/src/VectorServiceProvider.php
@@ -5,7 +5,13 @@ declare(strict_types=1);
 namespace TheShit\Vector;
 
 use Illuminate\Support\ServiceProvider;
+use TheShit\Vector\Contracts\EmbeddingClient;
 use TheShit\Vector\Contracts\VectorClient;
+use TheShit\Vector\Embeddings\NullEmbeddings;
+use TheShit\Vector\Embeddings\OllamaConnector;
+use TheShit\Vector\Embeddings\OllamaEmbeddings;
+use TheShit\Vector\Embeddings\OpenAiConnector;
+use TheShit\Vector\Embeddings\OpenAiEmbeddings;
 
 class VectorServiceProvider extends ServiceProvider
 {
@@ -25,6 +31,29 @@ class VectorServiceProvider extends ServiceProvider
         });
 
         $this->app->alias(Qdrant::class, VectorClient::class);
+
+        $this->app->singleton(EmbeddingClient::class, function (): EmbeddingClient {
+            $provider = config('vector.embeddings.provider', 'ollama');
+            $model = config('vector.embeddings.model', 'bge-large');
+
+            return match ($provider) {
+                'ollama' => new OllamaEmbeddings(
+                    new OllamaConnector(
+                        config('vector.embeddings.url', 'http://localhost:11434'),
+                    ),
+                    $model,
+                ),
+                'openai' => new OpenAiEmbeddings(
+                    new OpenAiConnector(
+                        config('vector.embeddings.url', 'https://api.openai.com'),
+                        config('vector.embeddings.api_key', ''),
+                    ),
+                    $model,
+                    config('vector.embeddings.dimensions') ? (int) config('vector.embeddings.dimensions') : null,
+                ),
+                default => new NullEmbeddings,
+            };
+        });
     }
 
     public function boot(): void

--- a/tests/Feature/EmbeddingServiceProviderTest.php
+++ b/tests/Feature/EmbeddingServiceProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use TheShit\Vector\Contracts\EmbeddingClient;
+use TheShit\Vector\Embeddings\NullEmbeddings;
+use TheShit\Vector\Embeddings\OllamaEmbeddings;
+use TheShit\Vector\Embeddings\OpenAiEmbeddings;
+use TheShit\Vector\Tests\TestCase;
+
+uses(TestCase::class);
+
+describe('VectorServiceProvider embedding resolution', function (): void {
+    it('resolves OllamaEmbeddings by default', function (): void {
+        config([
+            'vector.embeddings.provider' => 'ollama',
+            'vector.embeddings.url' => 'http://localhost:11434',
+        ]);
+        app()->forgetInstance(EmbeddingClient::class);
+
+        $client = app(EmbeddingClient::class);
+
+        expect($client)->toBeInstanceOf(OllamaEmbeddings::class);
+    });
+
+    it('resolves OpenAiEmbeddings when provider is openai', function (): void {
+        config([
+            'vector.embeddings.provider' => 'openai',
+            'vector.embeddings.url' => 'https://api.openai.com',
+            'vector.embeddings.api_key' => 'sk-test',
+        ]);
+        app()->forgetInstance(EmbeddingClient::class);
+
+        $client = app(EmbeddingClient::class);
+
+        expect($client)->toBeInstanceOf(OpenAiEmbeddings::class);
+    });
+
+    it('resolves NullEmbeddings when provider is none', function (): void {
+        config(['vector.embeddings.provider' => 'none']);
+        app()->forgetInstance(EmbeddingClient::class);
+
+        $client = app(EmbeddingClient::class);
+
+        expect($client)->toBeInstanceOf(NullEmbeddings::class);
+    });
+
+    it('resolves NullEmbeddings for unknown provider', function (): void {
+        config(['vector.embeddings.provider' => 'unknown-provider']);
+        app()->forgetInstance(EmbeddingClient::class);
+
+        $client = app(EmbeddingClient::class);
+
+        expect($client)->toBeInstanceOf(NullEmbeddings::class);
+    });
+});

--- a/tests/Feature/ListCollectionsTest.php
+++ b/tests/Feature/ListCollectionsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use TheShit\Vector\Qdrant;
+use TheShit\Vector\QdrantConnector;
+use TheShit\Vector\Requests\Collections\ListCollectionsRequest;
+use TheShit\Vector\Tests\TestCase;
+
+uses(TestCase::class);
+
+function makeListQdrant(MockClient $mock): Qdrant
+{
+    $connector = new QdrantConnector('http://localhost:6333', 'test-key');
+    $connector->withMockClient($mock);
+
+    return new Qdrant($connector);
+}
+
+describe('Qdrant::listCollections', function (): void {
+    it('returns collection names', function (): void {
+        $mock = new MockClient([
+            ListCollectionsRequest::class => MockResponse::make([
+                'result' => [
+                    'collections' => [
+                        ['name' => 'knowledge_default'],
+                        ['name' => 'code'],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $result = makeListQdrant($mock)->listCollections();
+
+        expect($result)->toBe(['knowledge_default', 'code']);
+    });
+
+    it('returns empty array when no collections', function (): void {
+        $mock = new MockClient([
+            ListCollectionsRequest::class => MockResponse::make([
+                'result' => [
+                    'collections' => [],
+                ],
+            ]),
+        ]);
+
+        $result = makeListQdrant($mock)->listCollections();
+
+        expect($result)->toBe([]);
+    });
+
+    it('handles null collections gracefully', function (): void {
+        $mock = new MockClient([
+            ListCollectionsRequest::class => MockResponse::make([
+                'result' => [],
+            ]),
+        ]);
+
+        $result = makeListQdrant($mock)->listCollections();
+
+        expect($result)->toBe([]);
+    });
+});

--- a/tests/Unit/EmbeddingsTest.php
+++ b/tests/Unit/EmbeddingsTest.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Http\Auth\TokenAuthenticator;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use TheShit\Vector\Contracts\EmbeddingClient;
+use TheShit\Vector\Embeddings\NullEmbeddings;
+use TheShit\Vector\Embeddings\OllamaConnector;
+use TheShit\Vector\Embeddings\OllamaEmbeddings;
+use TheShit\Vector\Embeddings\OpenAiConnector;
+use TheShit\Vector\Embeddings\OpenAiEmbeddings;
+use TheShit\Vector\Embeddings\Requests\OllamaEmbedRequest;
+use TheShit\Vector\Embeddings\Requests\OpenAiEmbedRequest;
+
+describe('OllamaConnector', function (): void {
+    it('resolves base url', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+
+        expect($connector->resolveBaseUrl())->toBe('http://localhost:11434');
+    });
+
+    it('trims trailing slash', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434/');
+
+        expect($connector->resolveBaseUrl())->toBe('http://localhost:11434');
+    });
+});
+
+describe('OpenAiConnector', function (): void {
+    it('resolves base url', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+
+        expect($connector->resolveBaseUrl())->toBe('https://api.openai.com');
+    });
+
+    it('sets bearer auth from api key', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test-key');
+        $auth = invade($connector)->defaultAuth();
+
+        expect($auth)->toBeInstanceOf(TokenAuthenticator::class);
+    });
+});
+
+describe('OllamaEmbedRequest', function (): void {
+    it('resolves endpoint', function (): void {
+        $request = new OllamaEmbedRequest('bge-large', ['hello']);
+
+        expect($request->resolveEndpoint())->toBe('/api/embed');
+    });
+
+    it('includes model and input in body', function (): void {
+        $request = new OllamaEmbedRequest('bge-large', ['hello', 'world']);
+        $body = invade($request)->defaultBody();
+
+        expect($body)->toBe([
+            'model' => 'bge-large',
+            'input' => ['hello', 'world'],
+        ]);
+    });
+});
+
+describe('OpenAiEmbedRequest', function (): void {
+    it('resolves endpoint', function (): void {
+        $request = new OpenAiEmbedRequest('text-embedding-3-large', ['hello']);
+
+        expect($request->resolveEndpoint())->toBe('/v1/embeddings');
+    });
+
+    it('includes model and input in body', function (): void {
+        $request = new OpenAiEmbedRequest('text-embedding-3-large', ['hello']);
+        $body = invade($request)->defaultBody();
+
+        expect($body)->toBe([
+            'model' => 'text-embedding-3-large',
+            'input' => ['hello'],
+        ]);
+    });
+
+    it('includes dimensions when specified', function (): void {
+        $request = new OpenAiEmbedRequest('text-embedding-3-large', ['hello'], 1024);
+        $body = invade($request)->defaultBody();
+
+        expect($body)->toBe([
+            'model' => 'text-embedding-3-large',
+            'input' => ['hello'],
+            'dimensions' => 1024,
+        ]);
+    });
+
+    it('omits dimensions when null', function (): void {
+        $request = new OpenAiEmbedRequest('text-embedding-3-large', ['hello']);
+        $body = invade($request)->defaultBody();
+
+        expect($body)->not->toHaveKey('dimensions');
+    });
+});
+
+describe('OllamaEmbeddings', function (): void {
+    it('embeds single text', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+        $connector->withMockClient(new MockClient([
+            OllamaEmbedRequest::class => MockResponse::make([
+                'embeddings' => [[0.1, 0.2, 0.3]],
+            ]),
+        ]));
+
+        $client = new OllamaEmbeddings($connector, 'bge-large');
+        $result = $client->embed('hello world');
+
+        expect($result)->toBe([0.1, 0.2, 0.3]);
+    });
+
+    it('returns empty array for empty text', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+        $client = new OllamaEmbeddings($connector);
+
+        expect($client->embed(''))->toBe([])
+            ->and($client->embed('   '))->toBe([]);
+    });
+
+    it('embeds batch of texts', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+        $connector->withMockClient(new MockClient([
+            OllamaEmbedRequest::class => MockResponse::make([
+                'embeddings' => [[0.1, 0.2], [0.3, 0.4]],
+            ]),
+        ]));
+
+        $client = new OllamaEmbeddings($connector, 'bge-large');
+        $result = $client->embedBatch(['hello', 'world']);
+
+        expect($result)->toBe([[0.1, 0.2], [0.3, 0.4]]);
+    });
+
+    it('filters empty strings from batch', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+        $connector->withMockClient(new MockClient([
+            OllamaEmbedRequest::class => MockResponse::make([
+                'embeddings' => [[0.1, 0.2]],
+            ]),
+        ]));
+
+        $client = new OllamaEmbeddings($connector, 'bge-large');
+        $result = $client->embedBatch(['hello', '', '  ']);
+
+        expect($result)->toBe([[0.1, 0.2]]);
+    });
+
+    it('returns empty arrays on batch with only empty strings', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+        $client = new OllamaEmbeddings($connector);
+
+        expect($client->embedBatch(['', '  ']))->toBe([]);
+    });
+
+    it('returns empty arrays on request failure', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+        $connector->withMockClient(new MockClient([
+            OllamaEmbedRequest::class => MockResponse::make([], 500),
+        ]));
+
+        $client = new OllamaEmbeddings($connector, 'bge-large');
+        $result = $client->embed('hello');
+
+        expect($result)->toBe([]);
+    });
+
+    it('handles malformed embedding response', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+        $connector->withMockClient(new MockClient([
+            OllamaEmbedRequest::class => MockResponse::make([
+                'embeddings' => ['not-an-array'],
+            ]),
+        ]));
+
+        $client = new OllamaEmbeddings($connector, 'bge-large');
+        $result = $client->embed('hello');
+
+        expect($result)->toBe([]);
+    });
+
+    it('handles missing embeddings key', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+        $connector->withMockClient(new MockClient([
+            OllamaEmbedRequest::class => MockResponse::make(['model' => 'bge-large']),
+        ]));
+
+        $client = new OllamaEmbeddings($connector, 'bge-large');
+        $result = $client->embed('hello');
+
+        expect($result)->toBe([]);
+    });
+
+    it('implements EmbeddingClient contract', function (): void {
+        $connector = new OllamaConnector('http://localhost:11434');
+        $client = new OllamaEmbeddings($connector);
+
+        expect($client)->toBeInstanceOf(EmbeddingClient::class);
+    });
+});
+
+describe('OpenAiEmbeddings', function (): void {
+    it('embeds single text', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $connector->withMockClient(new MockClient([
+            OpenAiEmbedRequest::class => MockResponse::make([
+                'data' => [['embedding' => [0.5, 0.6, 0.7]]],
+            ]),
+        ]));
+
+        $client = new OpenAiEmbeddings($connector, 'text-embedding-3-large');
+        $result = $client->embed('hello world');
+
+        expect($result)->toBe([0.5, 0.6, 0.7]);
+    });
+
+    it('returns empty array for empty text', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $client = new OpenAiEmbeddings($connector);
+
+        expect($client->embed(''))->toBe([])
+            ->and($client->embed('   '))->toBe([]);
+    });
+
+    it('embeds batch of texts', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $connector->withMockClient(new MockClient([
+            OpenAiEmbedRequest::class => MockResponse::make([
+                'data' => [
+                    ['embedding' => [0.1, 0.2]],
+                    ['embedding' => [0.3, 0.4]],
+                ],
+            ]),
+        ]));
+
+        $client = new OpenAiEmbeddings($connector, 'text-embedding-3-large');
+        $result = $client->embedBatch(['hello', 'world']);
+
+        expect($result)->toBe([[0.1, 0.2], [0.3, 0.4]]);
+    });
+
+    it('filters empty strings from batch', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $connector->withMockClient(new MockClient([
+            OpenAiEmbedRequest::class => MockResponse::make([
+                'data' => [['embedding' => [0.1, 0.2]]],
+            ]),
+        ]));
+
+        $client = new OpenAiEmbeddings($connector, 'text-embedding-3-large');
+        $result = $client->embedBatch(['hello', '', '  ']);
+
+        expect($result)->toBe([[0.1, 0.2]]);
+    });
+
+    it('returns empty on batch with only empty strings', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $client = new OpenAiEmbeddings($connector);
+
+        expect($client->embedBatch(['', '  ']))->toBe([]);
+    });
+
+    it('returns empty arrays on request failure', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $connector->withMockClient(new MockClient([
+            OpenAiEmbedRequest::class => MockResponse::make([], 500),
+        ]));
+
+        $client = new OpenAiEmbeddings($connector, 'text-embedding-3-large');
+        $result = $client->embed('hello');
+
+        expect($result)->toBe([]);
+    });
+
+    it('handles malformed data response', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $connector->withMockClient(new MockClient([
+            OpenAiEmbedRequest::class => MockResponse::make([
+                'data' => [['no_embedding_key' => true]],
+            ]),
+        ]));
+
+        $client = new OpenAiEmbeddings($connector, 'text-embedding-3-large');
+        $result = $client->embed('hello');
+
+        expect($result)->toBe([]);
+    });
+
+    it('handles missing data key', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $connector->withMockClient(new MockClient([
+            OpenAiEmbedRequest::class => MockResponse::make(['model' => 'text-embedding-3-large']),
+        ]));
+
+        $client = new OpenAiEmbeddings($connector, 'text-embedding-3-large');
+        $result = $client->embed('hello');
+
+        expect($result)->toBe([]);
+    });
+
+    it('passes dimensions to request', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $connector->withMockClient(new MockClient([
+            OpenAiEmbedRequest::class => MockResponse::make([
+                'data' => [['embedding' => [0.1]]],
+            ]),
+        ]));
+
+        $client = new OpenAiEmbeddings($connector, 'text-embedding-3-large', 1024);
+        $result = $client->embed('hello');
+
+        expect($result)->toBe([0.1]);
+    });
+
+    it('implements EmbeddingClient contract', function (): void {
+        $connector = new OpenAiConnector('https://api.openai.com', 'sk-test');
+        $client = new OpenAiEmbeddings($connector);
+
+        expect($client)->toBeInstanceOf(EmbeddingClient::class);
+    });
+});
+
+describe('NullEmbeddings', function (): void {
+    it('returns empty array for embed', function (): void {
+        $client = new NullEmbeddings;
+
+        expect($client->embed('hello'))->toBe([]);
+    });
+
+    it('returns empty array for embedBatch', function (): void {
+        $client = new NullEmbeddings;
+
+        expect($client->embedBatch(['hello', 'world']))->toBe([]);
+    });
+
+    it('implements EmbeddingClient contract', function (): void {
+        expect(new NullEmbeddings)->toBeInstanceOf(EmbeddingClient::class);
+    });
+});

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -6,6 +6,7 @@ use TheShit\Vector\Requests\Collections\AliasRequest;
 use TheShit\Vector\Requests\Collections\CreateCollectionRequest;
 use TheShit\Vector\Requests\Collections\DeleteCollectionRequest;
 use TheShit\Vector\Requests\Collections\GetCollectionRequest;
+use TheShit\Vector\Requests\Collections\ListCollectionsRequest;
 use TheShit\Vector\Requests\Points\CountPointsRequest;
 use TheShit\Vector\Requests\Points\CreatePayloadIndexRequest;
 use TheShit\Vector\Requests\Points\DeletePayloadIndexRequest;
@@ -468,5 +469,13 @@ describe('AliasRequest', function (): void {
                 ['create_alias' => ['collection_name' => 'memories_v2', 'alias_name' => 'memories']],
             ],
         ]);
+    });
+});
+
+describe('ListCollectionsRequest', function (): void {
+    it('resolves endpoint', function (): void {
+        $request = new ListCollectionsRequest;
+
+        expect($request->resolveEndpoint())->toBe('/collections');
     });
 });


### PR DESCRIPTION
## Summary

- `EmbeddingClient` contract with `embed()` and `embedBatch()`
- `OllamaEmbeddings` — Saloon connector calling `POST /api/embed`
- `OpenAiEmbeddings` — Saloon connector calling `POST /v1/embeddings` with Bearer auth (works with any OpenAI-compatible API)
- `NullEmbeddings` — stub for testing or disabled embedding
- Config-driven provider selection via `config/vector.php` (`ollama`, `openai`, `none`)
- `VectorServiceProvider` binds the correct implementation based on config

## New files

```
src/Contracts/EmbeddingClient.php
src/Embeddings/OllamaConnector.php
src/Embeddings/OllamaEmbeddings.php
src/Embeddings/OpenAiConnector.php
src/Embeddings/OpenAiEmbeddings.php
src/Embeddings/NullEmbeddings.php
src/Embeddings/Requests/OllamaEmbedRequest.php
src/Embeddings/Requests/OpenAiEmbedRequest.php
```

## Test plan

- [x] 176 tests pass (16 skipped contract tests needing live Qdrant)
- [x] 42 new embedding tests covering success, failure, empty input, malformed responses
- [x] Service provider resolution tests for all 3 providers + unknown
- [x] Pint clean

Closes #24